### PR TITLE
Deprecated calls With Atom version 0.196.0 

### DIFF
--- a/menus/css-comb.cson
+++ b/menus/css-comb.cson
@@ -1,7 +1,6 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer':
-      'Css Comb': 'css-comb:comb'
+  '.overlayer': [{  'Css Comb': 'css-comb:comb'  }]
 
 'menu': [
   {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "main": "./lib/css-comb",
   "version": "1.0.1",
   "description": "CSScomb is a coding style formatter for CSS. You can easily write your own configuration to make your style sheets beautiful and consistent.",
-  "activationEvents": [
-    "css-comb:comb",
-    "css-comb:userSettings"
-  ],
+  "activationCommands": {
+    "atom-text-editor": ["css-comb:comb", "css-comb:userSettings"]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jchouse/csscomb-atom"


### PR DESCRIPTION
Hi, @jchouse.

With Atom version 0.196.0 the plugin reports these following problems:

```javascript
The context menu CSON format has changed. Please see https://atom.io/docs/api/latest/ContextMenuManager#context-menu-cson-format for more info.
Called 1 time
Package.activateResources - /usr/share/atom/resources/app.asar/src/package.js:303:19
<unknown> - /usr/share/atom/resources/app.asar/src/package.js:199:21
Package.measure - /usr/share/atom/resources/app.asar/src/package.js:147:15
Package.activate - /usr/share/atom/resources/app.asar/src/package.js:195:14
```

```javascript
Use activationCommands instead of activationEvents in your package.json Commands should be grouped by selector as follows:

  "activationCommands": {
    "atom-workspace": ["foo:bar", "foo:baz"],
    "atom-text-editor": ["foo:quux"]
  }
Called 1 time
Package.getActivationCommands - /usr/share/atom/resources/app.asar/src/package.js:790:9
Package.hasActivationCommands - /usr/share/atom/resources/app.asar/src/package.js:715:20
<unknown> - /usr/share/atom/resources/app.asar/src/package.js:169:24
Package.measure - /usr/share/atom/resources/app.asar/src/package.js:147:15
```

I try to solve these problems. Hopefully,it will help you.
